### PR TITLE
Add a script injector for debugging

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,8 +6,16 @@ BUILD_DIR="${ROOT_DIR}/build"
 
 mkdir -p "${BUILD_DIR}"
 pushd "${BUILD_DIR}" >/dev/null
-qmake6 ../seb-linux-qt.pro
+CONFIG="debug"
+for arg in "$@"; do
+    if [ "$arg" == "-r" ] || [ "$arg" == "--release" ]; then
+        CONFIG="release"
+        break
+    fi
+done
+
+qmake6 CONFIG+="${CONFIG}" ../seb-linux-qt.pro
 make -j"$(nproc)"
 popd >/dev/null
 
-echo "Build output: ${BUILD_DIR}/bin/safe-exam-browser"
+echo "Build output: ${BUILD_DIR}/bin/safe-exam-browser (mode: ${CONFIG})"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,6 +85,10 @@ void applyCommandLineOverrides(const QCommandLineParser &parser, seb::SebSetting
     if (parser.isSet("disable-quit")) {
         settings.security.allowTermination = false;
     }
+
+    if (parser.isSet("inject")) {
+        settings.browser.injectedScript = parser.value("inject").trimmed();
+    }
 }
 
 }  // namespace
@@ -134,6 +138,10 @@ int main(int argc, char *argv[])
     parser.addOption(QCommandLineOption(
         QStringLiteral("disable-quit"),
         QStringLiteral("Disable manual termination even if the configuration allows it.")));
+    parser.addOption(QCommandLineOption(
+        QStringList{QStringLiteral("i"), QStringLiteral("inject")},
+        QStringLiteral("Inject a JavaScript file into each page."),
+        QStringLiteral("file")));
 
     parser.process(app);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,11 @@ QString findConfigPath(int argc, char *argv[])
         if ((argument == QStringLiteral("--config") || argument == QStringLiteral("-c")) && index + 1 < argc) {
             return QString::fromLocal8Bit(argv[index + 1]);
         }
+        if (argument == QStringLiteral("--url") || argument == QStringLiteral("-u") ||
+            argument == QStringLiteral("--inject") || argument == QStringLiteral("-i")) {
+            ++index;
+            continue;
+        }
         if (!argument.startsWith('-')) {
             return argument;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include <QLineEdit>
 #include <QTextStream>
 #include <QUrl>
+#include <QFileInfo>
 
 namespace {
 
@@ -87,7 +88,7 @@ void applyCommandLineOverrides(const QCommandLineParser &parser, seb::SebSetting
     }
 
     if (parser.isSet("inject")) {
-        settings.browser.injectedScript = parser.value("inject").trimmed();
+        settings.browser.injectedScript = QFileInfo(parser.value("inject")).absoluteFilePath();
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,11 @@ QString findConfigPath(int argc, char *argv[])
         if ((argument == QStringLiteral("--config") || argument == QStringLiteral("-c")) && index + 1 < argc) {
             return QString::fromLocal8Bit(argv[index + 1]);
         }
-        if (argument == QStringLiteral("--url") || argument == QStringLiteral("-u") ||
-            argument == QStringLiteral("--inject") || argument == QStringLiteral("-i")) {
+        if (argument == QStringLiteral("--url") || argument == QStringLiteral("-u")
+#ifdef QT_DEBUG
+            || argument == QStringLiteral("--inject") || argument == QStringLiteral("-i")
+#endif
+        ) {
             ++index;
             continue;
         }
@@ -92,9 +95,11 @@ void applyCommandLineOverrides(const QCommandLineParser &parser, seb::SebSetting
         settings.security.allowTermination = false;
     }
 
+#ifdef QT_DEBUG
     if (parser.isSet("inject")) {
         settings.browser.injectedScript = QFileInfo(parser.value("inject")).absoluteFilePath();
     }
+#endif
 }
 
 }  // namespace
@@ -144,10 +149,12 @@ int main(int argc, char *argv[])
     parser.addOption(QCommandLineOption(
         QStringLiteral("disable-quit"),
         QStringLiteral("Disable manual termination even if the configuration allows it.")));
+#ifdef QT_DEBUG
     parser.addOption(QCommandLineOption(
         QStringList{QStringLiteral("i"), QStringLiteral("inject")},
         QStringLiteral("Inject a JavaScript file into each page."),
         QStringLiteral("file")));
+#endif
 
     parser.process(app);
 

--- a/src/seb_session.cpp
+++ b/src/seb_session.cpp
@@ -27,6 +27,7 @@
 #include <QWebEngineDownloadRequest>
 #include <QWebEngineProfile>
 #include <QWebEngineSettings>
+#include <QTimer>
 
 namespace {
 

--- a/src/seb_session.cpp
+++ b/src/seb_session.cpp
@@ -19,6 +19,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QRegularExpression>
 #include <QStandardPaths>
 #include <QTemporaryDir>
 #include <QUrl>
@@ -408,10 +409,17 @@ void SebSession::handleDownloadRequested(QWebEngineDownloadRequest *download)
 
 QString SebSession::buildUserAgent() const
 {
-    QString agent = profile_->httpUserAgent();
+    QString agent;
 
     if (settings_.browser.useCustomUserAgent && !settings_.browser.customUserAgent.isEmpty()) {
         agent = settings_.browser.customUserAgent.trimmed();
+    } else {
+        QString defaultAgent = profile_->httpUserAgent();
+        QRegularExpression regex(QStringLiteral("Chrome/([0-9.]+)"));
+        QRegularExpressionMatch match = regex.match(defaultAgent);
+        QString chromeVersion = match.hasMatch() ? match.captured(1) : QStringLiteral("110.0.0.0");
+        
+        agent = QStringLiteral("Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/") + chromeVersion;
     }
 
     const QString sebVersion = QStringLiteral("SEB/") + getCachedSebVersion();

--- a/src/seb_session.cpp
+++ b/src/seb_session.cpp
@@ -26,6 +26,8 @@
 #include <QWebEngineCookieStore>
 #include <QWebEngineDownloadRequest>
 #include <QWebEngineProfile>
+#include <QWebEngineScript>
+#include <QWebEngineScriptCollection>
 #include <QWebEngineSettings>
 #include <QTimer>
 
@@ -114,6 +116,19 @@ SebSession::SebSession(const seb::SebSettings &settings, ResourceOpener opener, 
     profile_->setSpellCheckEnabled(settings_.browser.allowSpellChecking);
     profile_->setSpellCheckLanguages(QStringList{QLocale::system().bcp47Name()});
     profile_->setHttpUserAgent(buildUserAgent());
+
+    if (!settings_.browser.injectedScript.isEmpty()) {
+        QFile scriptFile(settings_.browser.injectedScript);
+        if (scriptFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            QWebEngineScript script;
+            script.setName(QStringLiteral("InjectScript"));
+            script.setSourceCode(QString::fromUtf8(scriptFile.readAll()));
+            script.setInjectionPoint(QWebEngineScript::DocumentReady);
+            script.setWorldId(QWebEngineScript::MainWorld);
+            script.setRunsOnSubFrames(true);
+            profile_->scripts()->insert(script);
+        }
+    }
 
     interceptor_.reset(new seb::browser::RequestInterceptor(settings_, this));
     profile_->setUrlRequestInterceptor(interceptor_.data());

--- a/src/seb_session.cpp
+++ b/src/seb_session.cpp
@@ -47,7 +47,12 @@ QString getCachedSebVersion()
     QEventLoop loop;
     QNetworkReply *reply = manager.get(request);
     QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
+
+    if (!reply->isFinished()) {
+        reply->abort();
+    }
 
     if (reply->error() == QNetworkReply::NoError) {
         const QByteArray responseData = reply->readAll();

--- a/src/seb_session.cpp
+++ b/src/seb_session.cpp
@@ -8,11 +8,17 @@
 #include <QAuthenticator>
 #include <QCryptographicHash>
 #include <QDir>
+#include <QEventLoop>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QInputDialog>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QLocale>
 #include <QMessageBox>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
 #include <QStandardPaths>
 #include <QTemporaryDir>
 #include <QUrl>
@@ -20,6 +26,47 @@
 #include <QWebEngineDownloadRequest>
 #include <QWebEngineProfile>
 #include <QWebEngineSettings>
+
+namespace {
+
+QString getCachedSebVersion()
+{
+    static QString cachedVersion;
+    if (!cachedVersion.isEmpty()) {
+        return cachedVersion;
+    }
+
+    cachedVersion = QStringLiteral("3.10.1");
+
+    QNetworkAccessManager manager;
+    QNetworkRequest request(QUrl(QStringLiteral("https://api.github.com/repos/SafeExamBrowser/seb-win-refactoring/releases/latest")));
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+    request.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("SEB Linux Qt/") + QApplication::applicationVersion());
+
+    QEventLoop loop;
+    QNetworkReply *reply = manager.get(request);
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    if (reply->error() == QNetworkReply::NoError) {
+        const QByteArray responseData = reply->readAll();
+        QJsonDocument json = QJsonDocument::fromJson(responseData);
+        if (json.isObject()) {
+            QString tag = json.object().value(QStringLiteral("tag_name")).toString();
+            if (!tag.isEmpty()) {
+                if (tag.startsWith(QLatin1Char('v'), Qt::CaseInsensitive)) {
+                    tag = tag.mid(1);
+                }
+                cachedVersion = tag;
+            }
+        }
+    }
+    reply->deleteLater();
+
+    return cachedVersion;
+}
+
+}  // namespace
 
 SebSession::SebSession(const seb::SebSettings &settings, ResourceOpener opener, QObject *parent)
     : QObject(parent)
@@ -366,6 +413,12 @@ QString SebSession::buildUserAgent() const
     if (settings_.browser.useCustomUserAgent && !settings_.browser.customUserAgent.isEmpty()) {
         agent = settings_.browser.customUserAgent.trimmed();
     }
+
+    const QString sebVersion = QStringLiteral("SEB/") + getCachedSebVersion();
+    if (!agent.endsWith(' ')) {
+        agent += QLatin1Char(' ');
+    }
+    agent += sebVersion;
 
     if (!settings_.browser.userAgentSuffix.trimmed().isEmpty()) {
         if (!agent.endsWith(' ')) {

--- a/src/seb_session.cpp
+++ b/src/seb_session.cpp
@@ -120,6 +120,7 @@ SebSession::SebSession(const seb::SebSettings &settings, ResourceOpener opener, 
     profile_->setSpellCheckLanguages(QStringList{QLocale::system().bcp47Name()});
     profile_->setHttpUserAgent(buildUserAgent());
 
+#ifdef QT_DEBUG
     if (!settings_.browser.injectedScript.isEmpty()) {
         QFile scriptFile(settings_.browser.injectedScript);
         if (scriptFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
@@ -135,6 +136,7 @@ SebSession::SebSession(const seb::SebSettings &settings, ResourceOpener opener, 
             qWarning() << "Failed to open injection script:" << scriptFile.fileName() << scriptFile.errorString();
         }
     }
+#endif
 
     interceptor_.reset(new seb::browser::RequestInterceptor(settings_, this));
     profile_->setUrlRequestInterceptor(interceptor_.data());

--- a/src/seb_session.cpp
+++ b/src/seb_session.cpp
@@ -7,8 +7,10 @@
 #include <QApplication>
 #include <QAuthenticator>
 #include <QCryptographicHash>
+#include <QDebug>
 #include <QDir>
 #include <QEventLoop>
+#include <QFile>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QInputDialog>
@@ -22,6 +24,7 @@
 #include <QRegularExpression>
 #include <QStandardPaths>
 #include <QTemporaryDir>
+#include <QTextStream>
 #include <QUrl>
 #include <QWebEngineCookieStore>
 #include <QWebEngineDownloadRequest>
@@ -122,11 +125,14 @@ SebSession::SebSession(const seb::SebSettings &settings, ResourceOpener opener, 
         if (scriptFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
             QWebEngineScript script;
             script.setName(QStringLiteral("InjectScript"));
-            script.setSourceCode(QString::fromUtf8(scriptFile.readAll()));
+            QTextStream in(&scriptFile);
+            script.setSourceCode(in.readAll());
             script.setInjectionPoint(QWebEngineScript::DocumentReady);
-            script.setWorldId(QWebEngineScript::MainWorld);
+            script.setWorldId(QWebEngineScript::UserWorld);
             script.setRunsOnSubFrames(true);
             profile_->scripts()->insert(script);
+        } else {
+            qWarning() << "Failed to open injection script:" << scriptFile.fileName() << scriptFile.errorString();
         }
     }
 

--- a/src/seb_settings.h
+++ b/src/seb_settings.h
@@ -125,6 +125,7 @@ struct BrowserSettings
     QString startUrl;
     QString startUrlQuery;
     QString userAgentSuffix;
+    QString injectedScript;
     bool allowConfigurationDownloads = true;
     bool allowCustomDownAndUploadLocation = false;
     bool allowDownloads = true;


### PR DESCRIPTION
## Summary
Add a script injector for debugging

## What Changed
Added a `-i`/`--inject` flag for injecting a javascript script that will run on each page loaded in order to more easily debug problems in the internal web engine.

## Verification
Builds on my machine and correctly injects script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a command-line option to inject a local JavaScript file into pages (path resolved; warns on load failure).
  * Automatically append the SEB version to the browser user agent, with improved detection of the embedded Chrome version.

* **Chores**
  * Build script now accepts an explicit mode (debug/release) and prints the selected mode on completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->