### PR TITLE
Anticheat

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,8 +6,16 @@ BUILD_DIR="${ROOT_DIR}/build"
 
 mkdir -p "${BUILD_DIR}"
 pushd "${BUILD_DIR}" >/dev/null
-qmake6 ../seb-linux-qt.pro
+CONFIG="debug"
+for arg in "$@"; do
+    if [ "$arg" == "-r" ] || [ "$arg" == "--release" ]; then
+        CONFIG="release"
+        break
+    fi
+done
+
+qmake6 CONFIG+="${CONFIG}" ../seb-linux-qt.pro
 make -j"$(nproc)"
 popd >/dev/null
 
-echo "Build output: ${BUILD_DIR}/bin/safe-exam-browser"
+echo "Build output: ${BUILD_DIR}/bin/safe-exam-browser (mode: ${CONFIG})"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,14 +24,16 @@ namespace {
 
 int g_tty0_fd = -1;
 int g_new_tty_fd = -1;
+int g_original_vt = -1;
 
 void cleanup_vt_and_exit() {
     if (g_new_tty_fd >= 0) {
         ioctl(g_new_tty_fd, KDSETMODE, KD_TEXT);
     }
     if (g_tty0_fd >= 0) {
-        ioctl(g_tty0_fd, VT_ACTIVATE, 1);
-        ioctl(g_tty0_fd, VT_WAITACTIVE, 1);
+        int target_vt = (g_original_vt > 0) ? g_original_vt : 1;
+        ioctl(g_tty0_fd, VT_ACTIVATE, target_vt);
+        ioctl(g_tty0_fd, VT_WAITACTIVE, target_vt);
     }
     if (g_new_tty_fd >= 0) close(g_new_tty_fd);
     if (g_tty0_fd >= 0) close(g_tty0_fd);
@@ -73,6 +75,11 @@ void setup_barebones_vt() {
     if (g_new_tty_fd < 0) {
         qWarning() << "Could not open VT" << vt_name;
         return;
+    }
+
+    struct vt_stat vts;
+    if (ioctl(g_tty0_fd, VT_GETSTATE, &vts) == 0) {
+        g_original_vt = vts.v_active;
     }
 
     ioctl(g_tty0_fd, VT_ACTIVATE, free_vt);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include <QUrl>
 #include <QProcess>
 #include <QProcessEnvironment>
+#include <QFileInfo>
 
 #include <fcntl.h>
 #include <unistd.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,8 +12,6 @@
 #include <QUrl>
 #include <QProcess>
 #include <QProcessEnvironment>
-#include <QTemporaryFile>
-#include <QDir>
 
 #include <fcntl.h>
 #include <unistd.h>
@@ -259,19 +257,10 @@ int main(int argc, char *argv[])
     QStringList warnings;
     if (!resource.isEmpty()) {
         const seb::ResourceLoadResult loaded = seb::loadSettingsFromResource(resource, [&userPassword, &usedPassword](bool hashed) {
-            if (qEnvironmentVariableIsSet("SEB_PASSWORD_FILE")) {
-                QString tempFilePath = QString::fromUtf8(qgetenv("SEB_PASSWORD_FILE"));
-                QFile file(tempFilePath);
-                if (file.open(QIODevice::ReadOnly)) {
-                    QByteArray data = file.readAll();
-                    userPassword = QString::fromUtf8(data);
-                    if (userPassword.endsWith('\n')) {
-                        userPassword.chop(1);
-                    }
-                    file.remove(); // Unlink immediately
-                    usedPassword = true;
-                    return userPassword;
-                }
+            if (qEnvironmentVariableIsSet("SEB_PASSWORD")) {
+                userPassword = QString::fromUtf8(qgetenv("SEB_PASSWORD"));
+                usedPassword = true;
+                return userPassword;
             }
 
             bool accepted = false;
@@ -313,17 +302,9 @@ int main(int argc, char *argv[])
             child.setProgram(QStringLiteral("pkexec"));
             
             QStringList pkexecArgs;
-            QTemporaryFile *tempFile = nullptr;
             if (usedPassword) {
-                tempFile = new QTemporaryFile(QDir::tempPath() + QStringLiteral("/seb-pass-XXXXXX"));
-                tempFile->setAutoRemove(false);
-                if (tempFile->open()) {
-                    tempFile->write(userPassword.toUtf8());
-                    tempFile->close();
-                    
-                    pkexecArgs << QStringLiteral("env");
-                    pkexecArgs << (QStringLiteral("SEB_PASSWORD_FILE=") + tempFile->fileName());
-                }
+                pkexecArgs << QStringLiteral("env");
+                pkexecArgs << (QStringLiteral("SEB_PASSWORD=") + userPassword);
             }
             
             pkexecArgs << QCoreApplication::applicationFilePath();
@@ -334,7 +315,6 @@ int main(int argc, char *argv[])
             if (child.startDetached()) {
                 return 0;
             }
-            delete tempFile;
             return 1;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,9 +10,81 @@
 #include <QLineEdit>
 #include <QTextStream>
 #include <QUrl>
-#include <QFileInfo>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QTemporaryFile>
+#include <QDir>
 
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <linux/vt.h>
+#include <linux/kd.h>
+#include <signal.h>
 namespace {
+
+int g_tty0_fd = -1;
+int g_new_tty_fd = -1;
+
+void cleanup_vt_and_exit() {
+    if (g_new_tty_fd >= 0) {
+        ioctl(g_new_tty_fd, KDSETMODE, KD_TEXT);
+    }
+    if (g_tty0_fd >= 0) {
+        ioctl(g_tty0_fd, VT_ACTIVATE, 1);
+        ioctl(g_tty0_fd, VT_WAITACTIVE, 1);
+    }
+    if (g_new_tty_fd >= 0) close(g_new_tty_fd);
+    if (g_tty0_fd >= 0) close(g_tty0_fd);
+}
+
+void barebones_sig_handler(int signum) {
+    cleanup_vt_and_exit();
+    if (signum == SIGSEGV || signum == SIGABRT || signum == SIGFPE || signum == SIGILL) {
+        signal(signum, SIG_DFL);
+        raise(signum);
+    } else {
+        _exit(1);
+    }
+}
+
+void setup_barebones_vt() {
+    signal(SIGINT, barebones_sig_handler);
+    signal(SIGTERM, barebones_sig_handler);
+    signal(SIGSEGV, barebones_sig_handler);
+    signal(SIGABRT, barebones_sig_handler);
+    signal(SIGILL, barebones_sig_handler);
+    signal(SIGFPE, barebones_sig_handler);
+
+    g_tty0_fd = open("/dev/tty0", O_RDWR);
+    if (g_tty0_fd < 0) {
+        qWarning() << "Could not open /dev/tty0. Did you run the app as root?";
+        return;
+    }
+
+    int free_vt = -1;
+    if (ioctl(g_tty0_fd, VT_OPENQRY, &free_vt) < 0 || free_vt == -1) {
+        qWarning() << "Could not find a free VT.";
+        return;
+    }
+
+    char vt_name[20];
+    snprintf(vt_name, sizeof(vt_name), "/dev/tty%d", free_vt);
+    g_new_tty_fd = open(vt_name, O_RDWR);
+    if (g_new_tty_fd < 0) {
+        qWarning() << "Could not open VT" << vt_name;
+        return;
+    }
+
+    ioctl(g_tty0_fd, VT_ACTIVATE, free_vt);
+    ioctl(g_tty0_fd, VT_WAITACTIVE, free_vt);
+
+    if (ioctl(g_new_tty_fd, KDSETMODE, KD_GRAPHICS) < 0) {
+        qWarning() << "Error setting graphics mode on VT" << free_vt;
+    }
+
+    atexit(cleanup_vt_and_exit);
+}
 
 QString findConfigPath(int argc, char *argv[])
 {
@@ -44,6 +116,15 @@ void applyEarlyEnvironment(int argc, char *argv[])
         const seb::LoadResult loaded = seb::loadSettingsFromFile(configPath);
         if (loaded.ok) {
             settings = loaded.settings;
+        }
+    }
+    for (int i = 0; i <= argc; ++i) { // we have to use a loop because the command line parser was not yet loaded.
+        if (QString::fromLocal8Bit(argv[i]) == QStringLiteral("--anti-cheat")) {
+            setup_barebones_vt();
+            qputenv("QT_QPA_PLATFORM", "linuxfb");
+            qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--no-sandbox");
+            qputenv("QT_QUICK_BACKEND", "software");
+            break;
         }
     }
 
@@ -82,7 +163,9 @@ void applyCommandLineOverrides(const QCommandLineParser &parser, seb::SebSetting
     if (parser.isSet("windowed")) {
         settings.browser.mainWindow.fullScreenMode = false;
     }
-
+    if (parser.isSet("fullscreen")){
+        settings.browser.mainWindow.fullScreenMode = true;
+    }
     if (parser.isSet("always-on-top")) {
         settings.browser.mainWindow.alwaysOnTop = true;
     }
@@ -109,7 +192,8 @@ int main(int argc, char *argv[])
     applyEarlyEnvironment(argc, argv);
 
     QApplication app(argc, argv);
-    const QIcon appIcon(QStringLiteral(":/assets/icons/safe-exam-browser.png"));
+    
+     const QIcon appIcon(QStringLiteral(":/assets/icons/safe-exam-browser.png"));
     app.setWindowIcon(appIcon);
     app.setDesktopFileName(QStringLiteral("safe-exam-browser"));
     QCoreApplication::setApplicationName(QStringLiteral("Safe Exam Browser"));
@@ -142,6 +226,7 @@ int main(int argc, char *argv[])
         QStringLiteral("allow-devtools"),
         QStringLiteral("Enable the developer tools shortcut (F12).")));
     parser.addOption(QCommandLineOption(QStringLiteral("windowed"), QStringLiteral("Force the main window to stay windowed.")));
+    parser.addOption(QCommandLineOption(QStringLiteral("fullscreen"), QStringLiteral("Force the main window to be fullscreen.")));
     parser.addOption(QCommandLineOption(QStringLiteral("always-on-top"), QStringLiteral("Keep the main window above other windows.")));
     parser.addOption(QCommandLineOption(
         QStringLiteral("disable-minimize"),
@@ -149,6 +234,9 @@ int main(int argc, char *argv[])
     parser.addOption(QCommandLineOption(
         QStringLiteral("disable-quit"),
         QStringLiteral("Disable manual termination even if the configuration allows it.")));
+    parser.addOption(QCommandLineOption(
+        QStringLiteral("anti-cheat"),
+        QStringLiteral("Enable anticheat mode.")));
 #ifdef QT_DEBUG
     parser.addOption(QCommandLineOption(
         QStringList{QStringLiteral("i"), QStringLiteral("inject")},
@@ -165,9 +253,27 @@ int main(int argc, char *argv[])
         ? parser.value("config")
         : (parser.positionalArguments().isEmpty() ? QString() : parser.positionalArguments().constFirst());
 
+    QString userPassword;
+    bool usedPassword = false;
+
     QStringList warnings;
     if (!resource.isEmpty()) {
-        const seb::ResourceLoadResult loaded = seb::loadSettingsFromResource(resource, [](bool hashed) {
+        const seb::ResourceLoadResult loaded = seb::loadSettingsFromResource(resource, [&userPassword, &usedPassword](bool hashed) {
+            if (qEnvironmentVariableIsSet("SEB_PASSWORD_FILE")) {
+                QString tempFilePath = QString::fromUtf8(qgetenv("SEB_PASSWORD_FILE"));
+                QFile file(tempFilePath);
+                if (file.open(QIODevice::ReadOnly)) {
+                    QByteArray data = file.readAll();
+                    userPassword = QString::fromUtf8(data);
+                    if (userPassword.endsWith('\n')) {
+                        userPassword.chop(1);
+                    }
+                    file.remove(); // Unlink immediately
+                    usedPassword = true;
+                    return userPassword;
+                }
+            }
+
             bool accepted = false;
             const QString password = QInputDialog::getText(
                 nullptr,
@@ -178,6 +284,10 @@ int main(int argc, char *argv[])
                 QLineEdit::Password,
                 QString(),
                 &accepted);
+            if (accepted) {
+                userPassword = password;
+                usedPassword = true;
+            }
             return accepted ? password : QString();
         });
         if (!loaded.ok) {
@@ -190,6 +300,44 @@ int main(int argc, char *argv[])
     }
 
     applyCommandLineOverrides(parser, settings);
+
+    if (!parser.isSet("anti-cheat")) {
+        if (settings.browser.mainWindow.fullScreenMode && settings.browser.mainWindow.alwaysOnTop) {
+            QStringList args = QCoreApplication::arguments();
+            args.removeFirst(); // Remove executable path
+            if (!args.contains(QStringLiteral("--anti-cheat"))) {
+                args.prepend(QStringLiteral("--anti-cheat"));
+            }
+            
+            QProcess child;
+            child.setProgram(QStringLiteral("pkexec"));
+            
+            QStringList pkexecArgs;
+            QTemporaryFile *tempFile = nullptr;
+            if (usedPassword) {
+                tempFile = new QTemporaryFile(QDir::tempPath() + QStringLiteral("/seb-pass-XXXXXX"));
+                tempFile->setAutoRemove(false);
+                if (tempFile->open()) {
+                    tempFile->write(userPassword.toUtf8());
+                    tempFile->close();
+                    
+                    pkexecArgs << QStringLiteral("env");
+                    pkexecArgs << (QStringLiteral("SEB_PASSWORD_FILE=") + tempFile->fileName());
+                }
+            }
+            
+            pkexecArgs << QCoreApplication::applicationFilePath();
+            pkexecArgs << args;
+            
+            child.setArguments(pkexecArgs);
+            
+            if (child.startDetached()) {
+                return 0;
+            }
+            delete tempFile;
+            return 1;
+        }
+    }
 
     AppController controller;
     QString launchError;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,7 +118,7 @@ void applyEarlyEnvironment(int argc, char *argv[])
             settings = loaded.settings;
         }
     }
-    for (int i = 0; i <= argc; ++i) { // we have to use a loop because the command line parser was not yet loaded.
+    for (int i = 0; i < argc; ++i) { // we have to use a loop because the command line parser was not yet loaded.
         if (QString::fromLocal8Bit(argv[i]) == QStringLiteral("--anti-cheat")) {
             setup_barebones_vt();
             qputenv("QT_QPA_PLATFORM", "linuxfb");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,6 +85,10 @@ void applyCommandLineOverrides(const QCommandLineParser &parser, seb::SebSetting
     if (parser.isSet("disable-quit")) {
         settings.security.allowTermination = false;
     }
+
+    if (parser.isSet("inject")) {
+        settings.browser.injectedScript = parser.value("inject").trimmed();
+    }
 }
 
 }  // namespace
@@ -134,6 +138,10 @@ int main(int argc, char *argv[])
     parser.addOption(QCommandLineOption(
         QStringLiteral("disable-quit"),
         QStringLiteral("Disable manual termination even if the configuration allows it.")));
+    parser.addOption(QCommandLineOption(
+        QStringList{QStringLiteral("i"), QStringLiteral("inject")},
+        QStringLiteral("Inject a JavaScript file into each page."),
+        QStringLiteral("file")));
 
     parser.process(app);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,11 @@ QString findConfigPath(int argc, char *argv[])
         if ((argument == QStringLiteral("--config") || argument == QStringLiteral("-c")) && index + 1 < argc) {
             return QString::fromLocal8Bit(argv[index + 1]);
         }
+        if (argument == QStringLiteral("--url") || argument == QStringLiteral("-u") ||
+            argument == QStringLiteral("--inject") || argument == QStringLiteral("-i")) {
+            ++index;
+            continue;
+        }
         if (!argument.startsWith('-')) {
             return argument;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include <QLineEdit>
 #include <QTextStream>
 #include <QUrl>
+#include <QFileInfo>
 
 namespace {
 
@@ -87,7 +88,7 @@ void applyCommandLineOverrides(const QCommandLineParser &parser, seb::SebSetting
     }
 
     if (parser.isSet("inject")) {
-        settings.browser.injectedScript = parser.value("inject").trimmed();
+        settings.browser.injectedScript = QFileInfo(parser.value("inject")).absoluteFilePath();
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,11 @@ QString findConfigPath(int argc, char *argv[])
         if ((argument == QStringLiteral("--config") || argument == QStringLiteral("-c")) && index + 1 < argc) {
             return QString::fromLocal8Bit(argv[index + 1]);
         }
-        if (argument == QStringLiteral("--url") || argument == QStringLiteral("-u") ||
-            argument == QStringLiteral("--inject") || argument == QStringLiteral("-i")) {
+        if (argument == QStringLiteral("--url") || argument == QStringLiteral("-u")
+#ifdef QT_DEBUG
+            || argument == QStringLiteral("--inject") || argument == QStringLiteral("-i")
+#endif
+        ) {
             ++index;
             continue;
         }
@@ -92,9 +95,11 @@ void applyCommandLineOverrides(const QCommandLineParser &parser, seb::SebSetting
         settings.security.allowTermination = false;
     }
 
+#ifdef QT_DEBUG
     if (parser.isSet("inject")) {
         settings.browser.injectedScript = QFileInfo(parser.value("inject")).absoluteFilePath();
     }
+#endif
 }
 
 }  // namespace
@@ -144,10 +149,12 @@ int main(int argc, char *argv[])
     parser.addOption(QCommandLineOption(
         QStringLiteral("disable-quit"),
         QStringLiteral("Disable manual termination even if the configuration allows it.")));
+#ifdef QT_DEBUG
     parser.addOption(QCommandLineOption(
         QStringList{QStringLiteral("i"), QStringLiteral("inject")},
         QStringLiteral("Inject a JavaScript file into each page."),
         QStringLiteral("file")));
+#endif
 
     parser.process(app);
 

--- a/src/seb_session.cpp
+++ b/src/seb_session.cpp
@@ -26,6 +26,8 @@
 #include <QWebEngineCookieStore>
 #include <QWebEngineDownloadRequest>
 #include <QWebEngineProfile>
+#include <QWebEngineScript>
+#include <QWebEngineScriptCollection>
 #include <QWebEngineSettings>
 #include <QTimer>
 
@@ -114,6 +116,19 @@ SebSession::SebSession(const seb::SebSettings &settings, ResourceOpener opener, 
     profile_->setSpellCheckEnabled(settings_.browser.allowSpellChecking);
     profile_->setSpellCheckLanguages(QStringList{QLocale::system().bcp47Name()});
     profile_->setHttpUserAgent(buildUserAgent());
+
+    if (!settings_.browser.injectedScript.isEmpty()) {
+        QFile scriptFile(settings_.browser.injectedScript);
+        if (scriptFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            QWebEngineScript script;
+            script.setName(QStringLiteral("InjectScript"));
+            script.setSourceCode(QString::fromUtf8(scriptFile.readAll()));
+            script.setInjectionPoint(QWebEngineScript::DocumentReady);
+            script.setWorldId(QWebEngineScript::MainWorld);
+            script.setRunsOnSubFrames(true);
+            profile_->scripts()->insert(script);
+        }
+    }
 
     interceptor_.reset(new seb::browser::RequestInterceptor(settings_, this));
     profile_->setUrlRequestInterceptor(interceptor_.data());

--- a/src/seb_session.cpp
+++ b/src/seb_session.cpp
@@ -120,6 +120,7 @@ SebSession::SebSession(const seb::SebSettings &settings, ResourceOpener opener, 
     profile_->setSpellCheckLanguages(QStringList{QLocale::system().bcp47Name()});
     profile_->setHttpUserAgent(buildUserAgent());
 
+#ifdef QT_DEBUG
     if (!settings_.browser.injectedScript.isEmpty()) {
         QFile scriptFile(settings_.browser.injectedScript);
         if (scriptFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
@@ -135,6 +136,7 @@ SebSession::SebSession(const seb::SebSettings &settings, ResourceOpener opener, 
             qWarning() << "Failed to open injection script:" << scriptFile.fileName() << scriptFile.errorString();
         }
     }
+#endif
 
     interceptor_.reset(new seb::browser::RequestInterceptor(settings_, this));
     profile_->setUrlRequestInterceptor(interceptor_.data());

--- a/src/seb_session.cpp
+++ b/src/seb_session.cpp
@@ -7,8 +7,10 @@
 #include <QApplication>
 #include <QAuthenticator>
 #include <QCryptographicHash>
+#include <QDebug>
 #include <QDir>
 #include <QEventLoop>
+#include <QFile>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QInputDialog>
@@ -22,6 +24,7 @@
 #include <QRegularExpression>
 #include <QStandardPaths>
 #include <QTemporaryDir>
+#include <QTextStream>
 #include <QUrl>
 #include <QWebEngineCookieStore>
 #include <QWebEngineDownloadRequest>
@@ -122,11 +125,14 @@ SebSession::SebSession(const seb::SebSettings &settings, ResourceOpener opener, 
         if (scriptFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
             QWebEngineScript script;
             script.setName(QStringLiteral("InjectScript"));
-            script.setSourceCode(QString::fromUtf8(scriptFile.readAll()));
+            QTextStream in(&scriptFile);
+            script.setSourceCode(in.readAll());
             script.setInjectionPoint(QWebEngineScript::DocumentReady);
-            script.setWorldId(QWebEngineScript::MainWorld);
+            script.setWorldId(QWebEngineScript::UserWorld);
             script.setRunsOnSubFrames(true);
             profile_->scripts()->insert(script);
+        } else {
+            qWarning() << "Failed to open injection script:" << scriptFile.fileName() << scriptFile.errorString();
         }
     }
 

--- a/src/seb_settings.h
+++ b/src/seb_settings.h
@@ -125,6 +125,7 @@ struct BrowserSettings
     QString startUrl;
     QString startUrlQuery;
     QString userAgentSuffix;
+    QString injectedScript;
     bool allowConfigurationDownloads = true;
     bool allowCustomDownAndUploadLocation = false;
     bool allowDownloads = true;


### PR DESCRIPTION
## Summary
Add secure anticheat

## What Changed
- Added anticheat: the app now opens a new virtual tty and draws the program to the frame buffer.
- When `always-on-top` and `fullscreenMode` are both true, enable anticheat.
- Added `--fullscreen` command line flag.

## Verification
- Works, except when dragging specifically text selections. When doing so, the drag preview shows a black box around itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build script now supports debug/release mode selection and shows the selected mode in its output

* **New Features**
  * Added --fullscreen command-line option
  * Added --anti-cheat command-line option with privilege-elevation support
  * Password can be provided via a temporary file/environment for automated authentication
  * Debug builds support custom browser script injection and a new injectedScript configuration field
<!-- end of auto-generated comment: release notes by coderabbit.ai -->