### PR TITLE
refactor: abstract browser view backend

### DIFF
--- a/seb-linux-qt.pro
+++ b/seb-linux-qt.pro
@@ -88,6 +88,7 @@ SOURCES += \
     src/browser/filters/RuleFactory.cpp \
     src/browser/filters/rules/RegexRule.cpp \
     src/browser/filters/rules/SimplifiedRule.cpp \
+    src/browser/engine/qtwebengine_browser_view.cpp \
     src/browser/key_generator.cpp \
     src/browser/request_filter.cpp \
     src/browser/request_interceptor.cpp \
@@ -324,6 +325,8 @@ HEADERS += \
     src/browser/filters/RuleFactory.h \
     src/browser/filters/rules/RegexRule.h \
     src/browser/filters/rules/SimplifiedRule.h \
+    src/browser/engine/browser_view.h \
+    src/browser/engine/qtwebengine_browser_view.h \
     src/browser/handlers/ContextMenuHandler.h \
     src/browser/handlers/CookieVisitor.h \
     src/browser/handlers/DialogHandler.h \

--- a/src/browser/BrowserControl.cpp
+++ b/src/browser/BrowserControl.cpp
@@ -1,11 +1,12 @@
 #include "BrowserControl.h"
 
-#include <QWebEngineHistory>
-#include <QWebEngineView>
+#include "engine/browser_view.h"
+
+#include <QUrl>
 
 namespace seb::browser {
 
-BrowserControl::BrowserControl(QWebEngineView *view, QObject *parent)
+BrowserControl::BrowserControl(seb::browser::engine::BrowserView *view, QObject *parent)
     : QObject(parent)
     , view_(view)
 {
@@ -18,17 +19,17 @@ QString BrowserControl::address() const
 
 bool BrowserControl::canNavigateBackwards() const
 {
-    return view_ && view_->history()->canGoBack();
+    return view_ && view_->canGoBack();
 }
 
 bool BrowserControl::canNavigateForwards() const
 {
-    return view_ && view_->history()->canGoForward();
+    return view_ && view_->canGoForward();
 }
 
 void BrowserControl::navigateTo(const QString &address)
 {
-    if (view_) view_->setUrl(QUrl::fromUserInput(address));
+    if (view_) view_->load(QUrl::fromUserInput(address));
 }
 
 void BrowserControl::navigateBackwards()

--- a/src/browser/BrowserControl.h
+++ b/src/browser/BrowserControl.h
@@ -3,9 +3,9 @@
 #include <QObject>
 #include <QString>
 
-QT_BEGIN_NAMESPACE
-class QWebEngineView;
-QT_END_NAMESPACE
+namespace seb::browser::engine {
+class BrowserView;
+}
 
 namespace seb::browser {
 
@@ -14,7 +14,7 @@ class BrowserControl : public QObject
     Q_OBJECT
 
 public:
-    explicit BrowserControl(QWebEngineView *view, QObject *parent = nullptr);
+    explicit BrowserControl(seb::browser::engine::BrowserView *view, QObject *parent = nullptr);
 
     QString address() const;
     bool canNavigateBackwards() const;
@@ -25,7 +25,7 @@ public:
     void reload();
 
 private:
-    QWebEngineView *view_ = nullptr;
+    seb::browser::engine::BrowserView *view_ = nullptr;
 };
 
 }  // namespace seb::browser

--- a/src/browser/BrowserWindow.cpp
+++ b/src/browser/BrowserWindow.cpp
@@ -43,7 +43,7 @@ bool BrowserWindowPort::isMainWindow() const
 
 QString BrowserWindowPort::url() const
 {
-    return window_ && window_->page() ? window_->page()->url().toString() : QString();
+    return window_ ? window_->currentUrl().toString() : QString();
 }
 
 BrowserWindowContext BrowserWindowPort::context() const
@@ -53,7 +53,7 @@ BrowserWindowContext BrowserWindowPort::context() const
         context.id = static_cast<int>(reinterpret_cast<quintptr>(window_) & 0x7fffffff);
         context.isMainWindow = window_->isMainWindow();
         context.title = window_->taskbarTitle();
-        context.url = window_->page() ? window_->page()->url().toString() : QString();
+        context.url = window_->currentUrl().toString();
     }
     return context;
 }

--- a/src/browser/engine/browser_view.h
+++ b/src/browser/engine/browser_view.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <functional>
+
+#include <QObject>
+#include <QUrl>
+
+QT_BEGIN_NAMESPACE
+class QWidget;
+QT_END_NAMESPACE
+
+namespace seb::browser::engine {
+
+class BrowserView : public QObject
+{
+    Q_OBJECT
+
+public:
+    using NavigationPolicy = std::function<bool(const QUrl &url, bool isMainFrame)>;
+    using FileChooserPolicy = std::function<bool()>;
+
+    explicit BrowserView(QObject *parent = nullptr) : QObject(parent) {}
+    ~BrowserView() override = default;
+
+    virtual QWidget *widget() = 0;
+
+    virtual QUrl url() const = 0;
+    virtual QString title() const = 0;
+
+    virtual bool canGoBack() const = 0;
+    virtual bool canGoForward() const = 0;
+
+    virtual void load(const QUrl &url) = 0;
+    virtual void back() = 0;
+    virtual void forward() = 0;
+    virtual void reload() = 0;
+
+    virtual void setNavigationPolicy(NavigationPolicy policy) = 0;
+    virtual void setUploadsAllowed(bool allowed) = 0;
+
+    // Find-in-page. Passing empty string should clear highlights.
+    virtual void findText(const QString &text) = 0;
+
+    // Optional; backends which cannot support devtools should no-op.
+    virtual void openDevTools() = 0;
+
+signals:
+    void urlChanged(const QUrl &url);
+    void titleChanged(const QString &title);
+    void newWindowRequested(const QUrl &targetUrl, const QUrl &openerUrl);
+};
+
+}  // namespace seb::browser::engine
+

--- a/src/browser/engine/qtwebengine_browser_view.cpp
+++ b/src/browser/engine/qtwebengine_browser_view.cpp
@@ -1,0 +1,172 @@
+#include "qtwebengine_browser_view.h"
+
+#include "../../seb_session.h"
+
+#include <QWebEngineHistory>
+#include <QWebEngineNewWindowRequest>
+#include <QWebEngineProfile>
+#include <QWebEngineView>
+
+namespace seb::browser::engine {
+
+QtWebEngineBrowserPage::QtWebEngineBrowserPage(SebSession &session, QObject *parent)
+    : QWebEnginePage(session.profile(), parent)
+    , session_(session)
+{
+}
+
+void QtWebEngineBrowserPage::setNavigationPolicy(BrowserView::NavigationPolicy policy)
+{
+    navigationPolicy_ = std::move(policy);
+}
+
+void QtWebEngineBrowserPage::setUploadsAllowed(bool allowed)
+{
+    uploadsAllowed_ = allowed;
+}
+
+bool QtWebEngineBrowserPage::acceptNavigationRequest(const QUrl &url, NavigationType type, bool isMainFrame)
+{
+    if (navigationPolicy_) {
+        if (!navigationPolicy_(url, isMainFrame)) {
+            return false;
+        }
+    }
+    return QWebEnginePage::acceptNavigationRequest(url, type, isMainFrame);
+}
+
+QStringList QtWebEngineBrowserPage::chooseFiles(
+    FileSelectionMode mode,
+    const QStringList &oldFiles,
+    const QStringList &acceptedMimeTypes)
+{
+    if (!uploadsAllowed_) {
+        return {};
+    }
+    return QWebEnginePage::chooseFiles(mode, oldFiles, acceptedMimeTypes);
+}
+
+QtWebEngineBrowserView::QtWebEngineBrowserView(
+    SebSession &session,
+    QWebEngineProfile *profile,
+    QWidget *parentWidget,
+    QObject *parent)
+    : BrowserView(parent)
+{
+    view_ = new QWebEngineView(parentWidget);
+    page_ = new QtWebEngineBrowserPage(session, view_);
+    if (profile) {
+        page_->setProfile(profile);
+    }
+    view_->setPage(page_);
+
+    connect(view_, &QWebEngineView::urlChanged, this, &BrowserView::urlChanged);
+    connect(view_, &QWebEngineView::titleChanged, this, &BrowserView::titleChanged);
+
+    connect(page_, &QWebEnginePage::newWindowRequested, this, [this](QWebEngineNewWindowRequest &request) {
+        const QUrl target = request.requestedUrl();
+        const QUrl opener = view_ ? view_->url() : QUrl();
+        emit newWindowRequested(target, opener);
+        // The caller will decide whether to open in same window or create a new one.
+        // We intentionally do not call request.openIn() here.
+    });
+}
+
+QtWebEngineBrowserView::~QtWebEngineBrowserView() = default;
+
+QWidget *QtWebEngineBrowserView::widget()
+{
+    return view_;
+}
+
+QUrl QtWebEngineBrowserView::url() const
+{
+    return view_ ? view_->url() : QUrl();
+}
+
+QString QtWebEngineBrowserView::title() const
+{
+    return view_ ? view_->title() : QString();
+}
+
+bool QtWebEngineBrowserView::canGoBack() const
+{
+    return view_ && view_->history() && view_->history()->canGoBack();
+}
+
+bool QtWebEngineBrowserView::canGoForward() const
+{
+    return view_ && view_->history() && view_->history()->canGoForward();
+}
+
+void QtWebEngineBrowserView::load(const QUrl &url)
+{
+    if (view_) {
+        view_->setUrl(url);
+    }
+}
+
+void QtWebEngineBrowserView::back()
+{
+    if (view_) {
+        view_->back();
+    }
+}
+
+void QtWebEngineBrowserView::forward()
+{
+    if (view_) {
+        view_->forward();
+    }
+}
+
+void QtWebEngineBrowserView::reload()
+{
+    if (view_) {
+        view_->reload();
+    }
+}
+
+void QtWebEngineBrowserView::setNavigationPolicy(NavigationPolicy policy)
+{
+    if (page_) {
+        page_->setNavigationPolicy(std::move(policy));
+    }
+}
+
+void QtWebEngineBrowserView::setUploadsAllowed(bool allowed)
+{
+    if (page_) {
+        page_->setUploadsAllowed(allowed);
+    }
+}
+
+void QtWebEngineBrowserView::findText(const QString &text)
+{
+    if (page_) {
+        page_->findText(text);
+    }
+}
+
+void QtWebEngineBrowserView::openDevTools()
+{
+    if (!page_) {
+        return;
+    }
+
+    auto *devTools = new QWebEngineView();
+    auto *devPage = new QWebEnginePage(page_->profile(), devTools);
+    page_->setDevToolsPage(devPage);
+    devTools->setPage(devPage);
+    devTools->setAttribute(Qt::WA_DeleteOnClose);
+    devTools->resize(1100, 700);
+    devTools->show();
+}
+
+QWebEnginePage *QtWebEngineBrowserView::page() const
+{
+    return page_;
+}
+
+}  // namespace seb::browser::engine
+

--- a/src/browser/engine/qtwebengine_browser_view.h
+++ b/src/browser/engine/qtwebengine_browser_view.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "browser_view.h"
+
+#include <QPointer>
+
+QT_BEGIN_NAMESPACE
+class QWebEnginePage;
+class QWebEngineProfile;
+class QWebEngineView;
+QT_END_NAMESPACE
+
+class SebSession;
+
+namespace seb::browser::engine {
+
+class QtWebEngineBrowserPage final : public QWebEnginePage
+{
+public:
+    QtWebEngineBrowserPage(SebSession &session, QObject *parent = nullptr);
+
+    void setNavigationPolicy(BrowserView::NavigationPolicy policy);
+    void setUploadsAllowed(bool allowed);
+
+protected:
+    bool acceptNavigationRequest(const QUrl &url, NavigationType type, bool isMainFrame) override;
+    QStringList chooseFiles(
+        FileSelectionMode mode,
+        const QStringList &oldFiles,
+        const QStringList &acceptedMimeTypes) override;
+
+private:
+    SebSession &session_;
+    BrowserView::NavigationPolicy navigationPolicy_;
+    bool uploadsAllowed_ = true;
+};
+
+class QtWebEngineBrowserView final : public BrowserView
+{
+    Q_OBJECT
+
+public:
+    QtWebEngineBrowserView(SebSession &session, QWebEngineProfile *profile, QWidget *parentWidget, QObject *parent = nullptr);
+    ~QtWebEngineBrowserView() override;
+
+    QWidget *widget() override;
+
+    QUrl url() const override;
+    QString title() const override;
+
+    bool canGoBack() const override;
+    bool canGoForward() const override;
+
+    void load(const QUrl &url) override;
+    void back() override;
+    void forward() override;
+    void reload() override;
+
+    void setNavigationPolicy(NavigationPolicy policy) override;
+    void setUploadsAllowed(bool allowed) override;
+    void findText(const QString &text) override;
+    void openDevTools() override;
+
+    QWebEnginePage *page() const;
+
+private:
+    QPointer<QWebEngineView> view_;
+    QPointer<QtWebEngineBrowserPage> page_;
+};
+
+}  // namespace seb::browser::engine
+

--- a/src/browser_window.cpp
+++ b/src/browser_window.cpp
@@ -19,37 +19,8 @@
 #include <QToolBar>
 #include <QUrl>
 #include <QVBoxLayout>
-#include <QWebEngineNewWindowRequest>
-#include <QWebEnginePage>
-#include <QWebEngineProfile>
-#include <QWebEngineSettings>
-#include <QWebEngineView>
 
-BrowserPage::BrowserPage(SebSession &session, BrowserWindow *window)
-    : QWebEnginePage(session.profile(), window)
-    , session_(session)
-    , window_(window)
-{
-}
-
-bool BrowserPage::acceptNavigationRequest(const QUrl &url, QWebEnginePage::NavigationType type, bool isMainFrame)
-{
-    if (isMainFrame && !window_->shouldAllowNavigation(url)) {
-        return false;
-    }
-    return QWebEnginePage::acceptNavigationRequest(url, type, isMainFrame);
-}
-
-QStringList BrowserPage::chooseFiles(
-    QWebEnginePage::FileSelectionMode mode,
-    const QStringList &oldFiles,
-    const QStringList &acceptedMimeTypes)
-{
-    if (!session_.settings().browser.allowUploads) {
-        return {};
-    }
-    return QWebEnginePage::chooseFiles(mode, oldFiles, acceptedMimeTypes);
-}
+#include "browser/engine/browser_view.h"
 
 BrowserWindow::BrowserWindow(
     SebSession &session,
@@ -67,10 +38,15 @@ BrowserWindow::BrowserWindow(
     contentLayout->setContentsMargins(0, 0, 0, 0);
     contentLayout->setSpacing(0);
 
-    view_ = new QWebEngineView(contentContainer_);
-    page_ = new BrowserPage(session_, this);
-    view_->setPage(page_);
-    contentLayout->addWidget(view_, 1);
+    view_ = session_.createBrowserView(contentContainer_);
+    view_->setNavigationPolicy([this](const QUrl &url, bool isMainFrame) {
+        if (isMainFrame) {
+            return shouldAllowNavigation(url);
+        }
+        return true;
+    });
+    view_->setUploadsAllowed(session_.settings().browser.allowUploads);
+    contentLayout->addWidget(view_->widget(), 1);
 
     if (isMainWindow_ && session_.settings().taskbar.enableTaskbar) {
         taskbar_ = new SebTaskbar(session_, session_.settings(), contentContainer_);
@@ -78,17 +54,14 @@ BrowserWindow::BrowserWindow(
     }
     setCentralWidget(contentContainer_);
 
-    view_->settings()->setAttribute(QWebEngineSettings::FullScreenSupportEnabled, false);
-    view_->settings()->setAttribute(QWebEngineSettings::JavascriptCanOpenWindows, true);
-
     if (!isMainWindow_) {
         configureToolbar();
     }
     configureShortcuts();
     applyWindowGeometry();
 
-    connect(view_, &QWebEngineView::urlChanged, this, &BrowserWindow::updateAddressBar);
-    connect(view_, &QWebEngineView::titleChanged, this, [this](const QString &title) {
+    connect(view_.get(), &seb::browser::engine::BrowserView::urlChanged, this, &BrowserWindow::updateAddressBar);
+    connect(view_.get(), &seb::browser::engine::BrowserView::titleChanged, this, [this](const QString &title) {
         const QString resolvedTitle = title.trimmed().isEmpty() ? QStringLiteral("SEB Linux") : title;
         setWindowTitle(resolvedTitle);
         if (taskbar_) {
@@ -96,14 +69,7 @@ BrowserWindow::BrowserWindow(
         }
         notifyTaskbarStateChanged();
     });
-    connect(page_, &QWebEnginePage::newWindowRequested, this, &BrowserWindow::handleNewWindowRequest);
-    connect(
-        page_,
-        &QWebEnginePage::proxyAuthenticationRequired,
-        this,
-        [this](const QUrl &, QAuthenticator *authenticator, const QString &proxyHost) {
-            session_.applyProxyAuthentication(proxyHost, authenticator);
-        });
+    connect(view_.get(), &seb::browser::engine::BrowserView::newWindowRequested, this, &BrowserWindow::handleNewWindowRequest);
     if (taskbar_) {
         connect(taskbar_, &SebTaskbar::quitRequested, this, [this] {
             if (isMainWindow_ &&
@@ -116,7 +82,7 @@ BrowserWindow::BrowserWindow(
     }
 
     if (initialUrl.isValid()) {
-        view_->setUrl(initialUrl);
+        view_->load(initialUrl);
     }
 
     session_.registerBrowserWindow(this);
@@ -128,9 +94,9 @@ BrowserWindow::~BrowserWindow()
     session_.unregisterBrowserWindow(this);
 }
 
-QWebEnginePage *BrowserWindow::page() const
+QUrl BrowserWindow::currentUrl() const
 {
-    return page_;
+    return view_ ? view_->url() : QUrl();
 }
 
 bool BrowserWindow::isMainWindow() const
@@ -155,7 +121,7 @@ bool BrowserWindow::shouldAllowNavigation(const QUrl &url)
         if (session_.settings().browser.resetOnQuitUrl) {
             const QUrl home = session_.homeUrl();
             if (home.isValid()) {
-                view_->setUrl(home);
+                view_->load(home);
             }
             return false;
         }
@@ -396,7 +362,9 @@ void BrowserWindow::configureToolbar()
         addressBar_->setPlaceholderText(QStringLiteral("Enter exam URL"));
         toolbar_->addWidget(addressBar_);
         connect(addressBar_, &QLineEdit::returnPressed, this, [this] {
-            view_->setUrl(QUrl::fromUserInput(addressBar_->text().trimmed()));
+            if (view_) {
+                view_->load(QUrl::fromUserInput(addressBar_->text().trimmed()));
+            }
         });
     }
 }
@@ -470,8 +438,10 @@ void BrowserWindow::findInPage()
         return;
     }
 
-    page_->findText(QString());
-    page_->findText(text);
+    if (view_) {
+        view_->findText(QString());
+        view_->findText(text);
+    }
 }
 
 void BrowserWindow::navigateHome()
@@ -485,7 +455,9 @@ void BrowserWindow::navigateHome()
         return;
     }
 
-    view_->setUrl(home);
+    if (view_) {
+        view_->load(home);
+    }
 }
 
 void BrowserWindow::openDevTools()
@@ -493,21 +465,14 @@ void BrowserWindow::openDevTools()
     if (!windowSettings_.allowDeveloperConsole) {
         return;
     }
-
-    auto *devTools = new QWebEngineView();
-    auto *devPage = new QWebEnginePage(session_.profile(), devTools);
-    page_->setDevToolsPage(devPage);
-    devTools->setPage(devPage);
-    devTools->setAttribute(Qt::WA_DeleteOnClose);
-    devTools->resize(1100, 700);
-    devTools->show();
+    if (view_) {
+        view_->openDevTools();
+    }
 }
 
-void BrowserWindow::handleNewWindowRequest(QWebEngineNewWindowRequest &request)
+void BrowserWindow::handleNewWindowRequest(const QUrl &target, const QUrl &opener)
 {
     bool openInSameWindow = false;
-    const QUrl target = request.requestedUrl();
-    const QUrl opener = view_->url();
 
     const QString scheme = target.scheme().toLower();
     if (scheme == QStringLiteral("seb") || scheme == QStringLiteral("sebs") ||
@@ -521,13 +486,14 @@ void BrowserWindow::handleNewWindowRequest(QWebEngineNewWindowRequest &request)
     }
 
     if (openInSameWindow) {
-        request.openIn(page_);
+        if (view_) {
+            view_->load(target);
+        }
         return;
     }
 
     auto *window = session_.createWindow(target, false);
     window->show();
-    request.openIn(window->page());
 }
 
 void BrowserWindow::reloadPage()
@@ -540,7 +506,9 @@ void BrowserWindow::reloadPage()
         return;
     }
 
-    view_->reload();
+    if (view_) {
+        view_->reload();
+    }
 }
 
 void BrowserWindow::updateAddressBar(const QUrl &url)

--- a/src/browser_window.h
+++ b/src/browser_window.h
@@ -2,8 +2,9 @@
 
 #include "seb_settings.h"
 
+#include <memory>
+
 #include <QMainWindow>
-#include <QWebEnginePage>
 
 QT_BEGIN_NAMESPACE
 class QAuthenticator;
@@ -15,31 +16,15 @@ class QLineEdit;
 class QToolBar;
 class QWidget;
 class QUrl;
-class QWebEngineNewWindowRequest;
-class QWebEngineView;
 QT_END_NAMESPACE
 
 class SebSession;
 class SebTaskbar;
 
 class BrowserWindow;
-
-class BrowserPage : public QWebEnginePage
-{
-public:
-    BrowserPage(SebSession &session, BrowserWindow *window);
-
-protected:
-    bool acceptNavigationRequest(const QUrl &url, QWebEnginePage::NavigationType type, bool isMainFrame) override;
-    QStringList chooseFiles(
-        QWebEnginePage::FileSelectionMode mode,
-        const QStringList &oldFiles,
-        const QStringList &acceptedMimeTypes) override;
-
-private:
-    SebSession &session_;
-    BrowserWindow *window_;
-};
+namespace seb::browser::engine {
+class BrowserView;
+}
 
 class BrowserWindow : public QMainWindow
 {
@@ -53,7 +38,7 @@ public:
         bool isMainWindow);
     ~BrowserWindow() override;
 
-    QWebEnginePage *page() const;
+    QUrl currentUrl() const;
     bool isMainWindow() const;
     bool shouldAllowNavigation(const QUrl &url);
     QString taskbarIconPath() const;
@@ -73,15 +58,14 @@ private:
     void findInPage();
     void navigateHome();
     void openDevTools();
-    void handleNewWindowRequest(QWebEngineNewWindowRequest &request);
+    void handleNewWindowRequest(const QUrl &targetUrl, const QUrl &openerUrl);
     void reloadPage();
     void updateAddressBar(const QUrl &url);
     void notifyTaskbarStateChanged();
 
     SebSession &session_;
     seb::WindowSettings windowSettings_;
-    QWebEngineView *view_ = nullptr;
-    BrowserPage *page_ = nullptr;
+    std::unique_ptr<seb::browser::engine::BrowserView> view_;
     QWidget *contentContainer_ = nullptr;
     QToolBar *toolbar_ = nullptr;
     QLineEdit *addressBar_ = nullptr;

--- a/src/seb_session.cpp
+++ b/src/seb_session.cpp
@@ -1,6 +1,7 @@
 #include "seb_session.h"
 
 #include "browser/request_interceptor.h"
+#include "browser/engine/qtwebengine_browser_view.h"
 #include "applications/application_manager.h"
 #include "browser_window.h"
 
@@ -272,6 +273,11 @@ const seb::SebSettings &SebSession::settings() const
 QWebEngineProfile *SebSession::profile() const
 {
     return profile_.data();
+}
+
+std::unique_ptr<seb::browser::engine::BrowserView> SebSession::createBrowserView(QWidget *parentWidget)
+{
+    return std::make_unique<seb::browser::engine::QtWebEngineBrowserView>(*this, profile_.data(), parentWidget);
 }
 
 QUrl SebSession::homeUrl() const

--- a/src/seb_session.h
+++ b/src/seb_session.h
@@ -12,6 +12,9 @@
 namespace seb::browser {
 class RequestInterceptor;
 }
+namespace seb::browser::engine {
+class BrowserView;
+}
 namespace seb::applications {
 class ApplicationManager;
 class ExternalApplication;
@@ -48,6 +51,7 @@ public:
     bool requestApplicationQuit(QWidget *parent, const QString &reason) const;
     const seb::SebSettings &settings() const;
     QWebEngineProfile *profile() const;
+    std::unique_ptr<seb::browser::engine::BrowserView> createBrowserView(QWidget *parentWidget);
     QUrl homeUrl() const;
     QUrl initialUrl() const;
     bool openSebResource(const QUrl &url, QWidget *parent) const;


### PR DESCRIPTION
Introduce a backend-agnostic BrowserView interface and route BrowserWindow/controls through it, with a QtWebEngine implementation as the first adapter.


## Summary

- 

## What Changed

- 

## Verification

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Developer Tools support enabling browser inspection and debugging capabilities
  * Introduced configurable navigation policies for enhanced browser control
  * Added explicit file upload permission management through policies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->