### PR TITLE
build(qmake): support forced browser backend selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /.vscode/
 /.idea/
 .codex
+/docs/next-update-plan.md

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,10 +3,26 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="${ROOT_DIR}/build"
+BUILD_CONFIG_STAMP="${BUILD_DIR}/.last-qmake-args"
+QMAKE_ARGS=("$@")
+QMAKE_ARGS_SERIALIZED="$(printf '%s\n' "${QMAKE_ARGS[@]}")"
 
 mkdir -p "${BUILD_DIR}"
 pushd "${BUILD_DIR}" >/dev/null
-qmake6 ../seb-linux-qt.pro "$@"
+
+PREVIOUS_QMAKE_ARGS=""
+if [[ -f "${BUILD_CONFIG_STAMP}" ]]; then
+  PREVIOUS_QMAKE_ARGS="$(cat "${BUILD_CONFIG_STAMP}")"
+fi
+
+if [[ -f Makefile && "${PREVIOUS_QMAKE_ARGS}" != "${QMAKE_ARGS_SERIALIZED}" ]]; then
+  echo "Detected changed qmake configuration; cleaning ${BUILD_DIR}"
+  make distclean >/dev/null 2>&1 || true
+fi
+
+echo "Configuring build with: qmake6 ../seb-linux-qt.pro ${QMAKE_ARGS[*]}"
+qmake6 ../seb-linux-qt.pro "${QMAKE_ARGS[@]}"
+printf '%s' "${QMAKE_ARGS_SERIALIZED}" > "${BUILD_CONFIG_STAMP}"
 make -j"$(nproc)"
 popd >/dev/null
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,24 +5,24 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="${ROOT_DIR}/build"
 BUILD_CONFIG_STAMP="${BUILD_DIR}/.last-qmake-args"
 QMAKE_ARGS=("$@")
-QMAKE_ARGS_SERIALIZED="$(printf '%s\n' "${QMAKE_ARGS[@]}")"
+QMAKE_ARGS_FINGERPRINT="$(printf '%s\0' "${QMAKE_ARGS[@]}" | sha256sum | awk '{print $1}')"
 
 mkdir -p "${BUILD_DIR}"
 pushd "${BUILD_DIR}" >/dev/null
 
-PREVIOUS_QMAKE_ARGS=""
+PREVIOUS_QMAKE_ARGS_FINGERPRINT=""
 if [[ -f "${BUILD_CONFIG_STAMP}" ]]; then
-  PREVIOUS_QMAKE_ARGS="$(cat "${BUILD_CONFIG_STAMP}")"
+  PREVIOUS_QMAKE_ARGS_FINGERPRINT="$(<"${BUILD_CONFIG_STAMP}")"
 fi
 
-if [[ -f Makefile && "${PREVIOUS_QMAKE_ARGS}" != "${QMAKE_ARGS_SERIALIZED}" ]]; then
+if [[ -f Makefile && "${PREVIOUS_QMAKE_ARGS_FINGERPRINT}" != "${QMAKE_ARGS_FINGERPRINT}" ]]; then
   echo "Detected changed qmake configuration; cleaning ${BUILD_DIR}"
   make distclean >/dev/null 2>&1 || true
 fi
 
 echo "Configuring build with: qmake6 ../seb-linux-qt.pro ${QMAKE_ARGS[*]}"
 qmake6 ../seb-linux-qt.pro "${QMAKE_ARGS[@]}"
-printf '%s' "${QMAKE_ARGS_SERIALIZED}" > "${BUILD_CONFIG_STAMP}"
+printf '%s\n' "${QMAKE_ARGS_FINGERPRINT}" > "${BUILD_CONFIG_STAMP}"
 make -j"$(nproc)"
 popd >/dev/null
 

--- a/seb-linux-qt.pro
+++ b/seb-linux-qt.pro
@@ -2,24 +2,61 @@ QT += core gui widgets network xml
 
 # Safe Exam Browser for Linux: Browser Engine Detection
 # We support Qt WebEngine (primary) and WebKitGTK (fallback for RISC-V/Older systems).
-equals(QT_MAJOR_VERSION, 6):qtHaveModule(webenginecore):qtHaveModule(webenginewidgets) {
-    QT += webenginecore webenginewidgets
-    DEFINES += SEB_HAS_QTWEBENGINE=1
-    DEFINES += SEB_HAS_ANY_ENGINE=1
-} else {
-    DEFINES += SEB_HAS_QTWEBENGINE=0
-    # Check for WebKitGTK using pkg-config
-    CONFIG += link_pkgconfig
-    packagesExist(webkit2gtk-4.1 gtk+-3.0) {
-        DEFINES += SEB_HAS_WEBKITGTK=1
-        DEFINES += SEB_HAS_ANY_ENGINE=1
-        PKGCONFIG += webkit2gtk-4.1 gtk+-3.0
-        message("Building with WebKitGTK fallback (QtWebEngine not found or unsupported).")
-    } else {
-        DEFINES += SEB_HAS_ANY_ENGINE=0
-        warning("No supported browser engine found (QtWebEngine/WebKitGTK missing). The app will show an error on startup.")
-    }
+CONFIG += link_pkgconfig
+
+force_qtwebengine:force_webkitgtk {
+    error("CONFIG+=force_qtwebengine and CONFIG+=force_webkitgtk cannot be used together.")
 }
+
+qtwebengine_available = false
+equals(QT_MAJOR_VERSION, 6):qtHaveModule(webenginecore):qtHaveModule(webenginewidgets) {
+    qtwebengine_available = true
+}
+
+webkitgtk_available = false
+packagesExist(webkit2gtk-4.1 gtk+-3.0) {
+    webkitgtk_available = true
+}
+
+seb_has_qtwebengine = 0
+seb_has_webkitgtk = 0
+seb_has_any_engine = 0
+
+force_qtwebengine {
+    equals(qtwebengine_available, false) {
+        error("CONFIG+=force_qtwebengine was requested, but Qt WebEngine modules are unavailable.")
+    }
+
+    QT += webenginecore webenginewidgets
+    seb_has_qtwebengine = 1
+    seb_has_any_engine = 1
+    message("Building with Qt WebEngine (forced via CONFIG+=force_qtwebengine).")
+} else:force_webkitgtk {
+    equals(webkitgtk_available, false) {
+        error("CONFIG+=force_webkitgtk was requested, but pkg-config could not find webkit2gtk-4.1 and gtk+-3.0.")
+    }
+
+    PKGCONFIG += webkit2gtk-4.1 gtk+-3.0
+    seb_has_webkitgtk = 1
+    seb_has_any_engine = 1
+    message("Building with WebKitGTK fallback (forced via CONFIG+=force_webkitgtk).")
+} else:equals(qtwebengine_available, true) {
+    QT += webenginecore webenginewidgets
+    seb_has_qtwebengine = 1
+    seb_has_any_engine = 1
+    message("Building with Qt WebEngine (auto-detected).")
+} else:equals(webkitgtk_available, true) {
+    PKGCONFIG += webkit2gtk-4.1 gtk+-3.0
+    seb_has_webkitgtk = 1
+    seb_has_any_engine = 1
+    message("Building with WebKitGTK fallback (Qt WebEngine unavailable; auto-detected).")
+} else {
+    warning("No supported browser engine found (QtWebEngine/WebKitGTK missing). The app will show an error on startup.")
+}
+
+DEFINES += SEB_HAS_QTWEBENGINE=$$seb_has_qtwebengine
+DEFINES += SEB_HAS_WEBKITGTK=$$seb_has_webkitgtk
+DEFINES += SEB_HAS_ANY_ENGINE=$$seb_has_any_engine
 
 # Dev Bypass Build Option
 # Usage: qmake CONFIG+=dev_bypass

--- a/seb-linux-qt.pro
+++ b/seb-linux-qt.pro
@@ -2,8 +2,6 @@ QT += core gui widgets network xml
 
 # Safe Exam Browser for Linux: Browser Engine Detection
 # We support Qt WebEngine (primary) and WebKitGTK (fallback for RISC-V/Older systems).
-CONFIG += link_pkgconfig
-
 force_qtwebengine:force_webkitgtk {
     error("CONFIG+=force_qtwebengine and CONFIG+=force_webkitgtk cannot be used together.")
 }
@@ -14,8 +12,16 @@ equals(QT_MAJOR_VERSION, 6):qtHaveModule(webenginecore):qtHaveModule(webenginewi
 }
 
 webkitgtk_available = false
-packagesExist(webkit2gtk-4.1 gtk+-3.0) {
-    webkitgtk_available = true
+force_webkitgtk {
+    CONFIG += link_pkgconfig
+    packagesExist(webkit2gtk-4.1 gtk+-3.0) {
+        webkitgtk_available = true
+    }
+} else:!equals(qtwebengine_available, true) {
+    CONFIG += link_pkgconfig
+    packagesExist(webkit2gtk-4.1 gtk+-3.0) {
+        webkitgtk_available = true
+    }
 }
 
 seb_has_qtwebengine = 0

--- a/src/browser_window.cpp
+++ b/src/browser_window.cpp
@@ -420,40 +420,6 @@ void BrowserWindow::configureToolbar()
     }
 }
 
-void BrowserWindow::configureFallbackView(const QUrl &initialUrl)
-{
-#if SEB_HAS_QTWEBENGINE
-    Q_UNUSED(initialUrl);
-#else
-    fallbackUrl_ = initialUrl;
-    if (!fallbackView_) {
-        fallbackView_ = new QTextBrowser(contentContainer_);
-        fallbackView_->setFrameShape(QFrame::NoFrame);
-        fallbackView_->setOpenLinks(false);
-        fallbackView_->setOpenExternalLinks(false);
-        fallbackView_->setReadOnly(true);
-        fallbackView_->setTextInteractionFlags(Qt::TextSelectableByKeyboard | Qt::TextSelectableByMouse);
-    }
-
-    const QString targetUrl = fallbackUrl_.isValid()
-        ? fallbackUrl_.toDisplayString()
-        : QStringLiteral("Not configured");
-    const QString homeUrl = session_.homeUrl().isValid()
-        ? session_.homeUrl().toDisplayString()
-        : QStringLiteral("Not configured");
-
-    fallbackView_->setHtml(QStringLiteral(
-        "<h2>Qt WebEngine Is Unavailable</h2>"
-        "<p>This build can still load SEB configuration, start the protected shell, and exercise the Linux UI, "
-        "but it cannot render exam pages because Qt WebEngine is disabled for this target.</p>"
-        "<p><b>Current target URL:</b> <code>%1</code><br/>"
-        "<b>Configured home URL:</b> <code>%2</code></p>"
-        "<p>This compatibility mode is intended for architectures such as riscv64 until a supported "
-        "embedded browser engine becomes available.</p>")
-            .arg(targetUrl.toHtmlEscaped(), homeUrl.toHtmlEscaped()));
-#endif
-}
-
 void BrowserWindow::configureShortcuts()
 {
     auto *reloadAction = new QAction(this);

--- a/src/browser_window.h
+++ b/src/browser_window.h
@@ -67,7 +67,6 @@ private:
     void applyWindowFlags();
     void applyWindowGeometry();
     void configureToolbar();
-    void configureFallbackView(const QUrl &initialUrl);
     void configureShortcuts();
     void findInPage();
     void navigateHome();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

This release improves build reliability and browser engine configuration management.

* **Chores**
  * Updated build ignore patterns to exclude a planning document.
* **Refactor**
  * Build script now tracks qmake arguments and conditionally triggers clean rebuilds when configuration changes.
  * Browser engine selection/detection logic reorganized for clearer handling of available engines.
  * Removed the previous fallback view used when one browser backend was unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->