### PR TITLE
Run pkexec non-detached

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -148,6 +148,20 @@ static void appendPkexecEnvironmentVariable(QStringList &args, const char *name)
     }
 }
 
+static int runNonDetachedPkexecChild( QProcess& child )
+{
+  // Do not detach. Forward outputs to parent.
+  child.setProcessChannelMode(QProcess::ForwardedChannels);
+  child.start();
+  if (child.waitForFinished( -1 /* no timeout */ )) {
+    qDebug() << "pkexec child finished\n";
+    return 0;
+  } else {
+    qDebug() << "pkexec child failed\n";
+    return 1;
+  }
+}
+
 void applyProtectedWindowSettings(seb::WindowSettings &settings, bool fullScreen)
 {
     settings.absoluteHeight = 0;
@@ -443,10 +457,7 @@ int main(int argc, char *argv[])
             pkexecArgs << args;
 
             child.setArguments(pkexecArgs);
-            if (child.startDetached()) {
-                return 0;
-            }
-            return 1;
+            return runNonDetachedPkexecChild( child );
         }
 
         const bool requiresLockedExamShell =
@@ -490,11 +501,7 @@ int main(int argc, char *argv[])
             pkexecArgs << args;
             
             child.setArguments(pkexecArgs);
-            
-            if (child.startDetached()) {
-                return 0;
-            }
-            return 1;
+            return runNonDetachedPkexecChild( child );
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,11 +153,16 @@ static int runNonDetachedPkexecChild( QProcess& child )
   // Do not detach. Forward outputs to parent.
   child.setProcessChannelMode(QProcess::ForwardedChannels);
   child.start();
+  if (!child.waitForStarted()) {
+    qDebug() << "pkexec child failed to start:" << child.errorString();
+    return 1;
+  }
   if (child.waitForFinished( -1 /* no timeout */ )) {
-    qDebug() << "pkexec child finished\n";
-    return 0;
+    const int exitCode = child.exitCode();
+    qDebug() << "pkexec child finished with exit code" << exitCode;
+    return exitCode;
   } else {
-    qDebug() << "pkexec child failed\n";
+    qDebug() << "pkexec child failed:" << child.errorString();
     return 1;
   }
 }
@@ -457,7 +462,7 @@ int main(int argc, char *argv[])
             pkexecArgs << args;
 
             child.setArguments(pkexecArgs);
-            return runNonDetachedPkexecChild( child );
+            return runNonDetachedPkexecChild(child);
         }
 
         const bool requiresLockedExamShell =
@@ -501,7 +506,7 @@ int main(int argc, char *argv[])
             pkexecArgs << args;
             
             child.setArguments(pkexecArgs);
-            return runNonDetachedPkexecChild( child );
+            return runNonDetachedPkexecChild(child);
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -148,23 +148,30 @@ static void appendPkexecEnvironmentVariable(QStringList &args, const char *name)
     }
 }
 
-static int runNonDetachedPkexecChild( QProcess& child )
+static int runNonDetachedPkexecChild(QProcess &child)
 {
-  // Do not detach. Forward outputs to parent.
-  child.setProcessChannelMode(QProcess::ForwardedChannels);
-  child.start();
-  if (!child.waitForStarted()) {
-    qDebug() << "pkexec child failed to start:" << child.errorString();
-    return 1;
-  }
-  if (child.waitForFinished( -1 /* no timeout */ )) {
+    // Do not detach. Forward outputs to parent.
+    child.setProcessChannelMode(QProcess::ForwardedChannels);
+
+    child.start();
+    if (!child.waitForStarted()) {
+        qWarning() << "pkexec child failed to start:" << child.errorString();
+        return 1;
+    }
+
+    if (!child.waitForFinished(-1 /* no timeout */)) {
+        qWarning() << "pkexec child failed:" << child.errorString();
+        return 1;
+    }
+
+    if (child.exitStatus() != QProcess::NormalExit) {
+        qWarning() << "pkexec child crashed";
+        return 1;
+    }
+
     const int exitCode = child.exitCode();
     qDebug() << "pkexec child finished with exit code" << exitCode;
     return exitCode;
-  } else {
-    qDebug() << "pkexec child failed:" << child.errorString();
-    return 1;
-  }
 }
 
 void applyProtectedWindowSettings(seb::WindowSettings &settings, bool fullScreen)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -306,9 +306,11 @@ void applyCommandLineOverrides(const QCommandLineParser &parser, seb::SebSetting
         settings.security.allowTermination = false;
     }
 
+#if defined(QT_DEBUG) || defined(SEB_DEV_BYPASS_OPTION)
     if (parser.isSet("dev-bypass")) {
         settings.devBypass = true;
     }
+#endif
 }
 
 }  // namespace
@@ -429,7 +431,11 @@ int main(int argc, char *argv[])
     const bool launchedWithoutExam = resource.isEmpty();
     const bool menuLockdown = parser.isSet("menu-lockdown");
     const bool examAntiCheat = parser.isSet("anti-cheat");
+#if defined(QT_DEBUG) || defined(SEB_DEV_BYPASS_OPTION)
     bool devBypass = settings.devBypass || parser.isSet("dev-bypass");
+#else
+    bool devBypass = settings.devBypass;
+#endif
 #ifdef SEB_DEV_BYPASS_DEFAULT
     devBypass = true;
 #endif


### PR DESCRIPTION
## Summary

- https://github.com/Jvr2022/seb-linux/issues/22#issue-4562975873

## What Changed
- pkexec is run as a non-detached child

## Verification
-  compiles
- In a terminal window:  ./build/bin/safe-exam-browser
- Asks "Do you want to continue"
- "Yes"
- pkexec asks password
- (providing password)
- safe-exam-browser takes over the screen
- (click Quit button)
- exits  (we are back to the terminal)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Privilege escalation now waits for the helper process to finish and returns its result as the application's exit code, instead of proceeding immediately. This ensures elevated operations complete before the app continues, improving reliability and consistency during administrative tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->