### PR TITLE
Cleanup build script + fix -v

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 project(safe-exam-browser LANGUAGES C CXX)
 
+set(VERSION "$ENV{VERSION}")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -398,6 +399,8 @@ qt_add_executable(safe-exam-browser
     ${SEB_HEADERS}
     resources.qrc
 )
+
+add_compile_definitions(VERSION="${VERSION}")
 
 target_include_directories(safe-exam-browser PRIVATE src)
 target_compile_options(safe-exam-browser PRIVATE -Wall -Wextra -Wpedantic)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.21)
 project(safe-exam-browser LANGUAGES C CXX)
 
 set(VERSION "$ENV{VERSION}")
+set(PACKAGE_NAME "$ENV{PACKAGE_NAME}")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -401,6 +402,7 @@ qt_add_executable(safe-exam-browser
 )
 
 add_compile_definitions(VERSION="${VERSION}")
+add_compile_definitions(PACKAGE_NAME="${PACKAGE_NAME}")
 
 target_include_directories(safe-exam-browser PRIVATE src)
 target_compile_options(safe-exam-browser PRIVATE -Wall -Wextra -Wpedantic)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,23 @@ We want to fix that!
 Please [open an issue here](https://github.com/Jvr2022/seb-linux/issues)
 with some details about your system and what version of Linux you're using.
 
+## Known issues
+
+### Unable to spawn a new child process: Failed to spawn child process “/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1/WebKitNetworkProcess”
+
+It is impossible for WebKitGTK-dependent packages to utilize the libraries from
+inside the AppImage, hence you have to have webkit2gtk-4.1 installed,
+and as far as I can tell it only works with debian systems.
+
+The workarounds are:
+
+- Using the QT build.
+- Installing the package.
+- Running a debian container.
+
+Although we can't seem to fix this, we might provide other backends
+as an alternative or there may be a fix in the future.
+
 ## License
 
 This is an open-source project licensed under the `MPL2`.

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ with some details about your system and what version of Linux you're using.
 
 It is impossible for WebKitGTK-dependent packages to utilize the libraries from
 inside the AppImage, hence you have to have webkit2gtk-4.1 installed,
-and as far as I can tell it only works with debian systems.
+and as far as I can tell it only works on Debian-based systems.
 
 The workarounds are:
 
-- Using the QT build.
+- Using the Qt build.
 - Installing the package.
-- Running a debian container.
+- Running a Debian container.
 
 Although we can't seem to fix this, we might provide other backends
 as an alternative or there may be a fix in the future.

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -29,6 +29,7 @@ LINUXBUILD_EXTRA_ARGS=(
     -l /usr/lib/x86_64-linux-gnu/libtiff.so.6
     -l /usr/lib/x86_64-linux-gnu/libxcb-cursor.so.0
     -l /usr/lib/x86_64-linux-gnu/libxcb-xinput.so.0
+    -l /usr/lib/x86_64-linux-gnu/webkit2gtk-4.1/WebKitWebProcess
 )
 # -l /usr/lib/x86_64-linux-gnu/libnghttp3.so.9
 # -l /usr/lib/x86_64-linux-gnu/libngtcp2.so.16 -l /usr/lib/x86_64-linux-gnu/libngtcp2_crypto_gnutls.so.8

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -29,7 +29,6 @@ LINUXBUILD_EXTRA_ARGS=(
     -l /usr/lib/x86_64-linux-gnu/libtiff.so.6
     -l /usr/lib/x86_64-linux-gnu/libxcb-cursor.so.0
     -l /usr/lib/x86_64-linux-gnu/libxcb-xinput.so.0
-    -l /usr/lib/x86_64-linux-gnu/webkit2gtk-4.1/WebKitWebProcess
 )
 # -l /usr/lib/x86_64-linux-gnu/libnghttp3.so.9
 # -l /usr/lib/x86_64-linux-gnu/libngtcp2.so.16 -l /usr/lib/x86_64-linux-gnu/libngtcp2_crypto_gnutls.so.8

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -30,10 +30,7 @@ LINUXBUILD_EXTRA_ARGS=(
     -l /usr/lib/x86_64-linux-gnu/libxcb-cursor.so.0
     -l /usr/lib/x86_64-linux-gnu/libxcb-xinput.so.0
 )
-# -l /usr/lib/x86_64-linux-gnu/libnghttp3.so.9
-# -l /usr/lib/x86_64-linux-gnu/libngtcp2.so.16 -l /usr/lib/x86_64-linux-gnu/libngtcp2_crypto_gnutls.so.8
-# -l /usr/lib/x86_64-linux-gnu/libQt6QmlMeta.so.6
-# -l /usr/lib/x86_64-linux-gnu/libxml2.so.16
+export VERSION="${1:-0.1.0}"
 echo "Variables set"
 
 GENERATOR_ARGS=()

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -8,9 +8,9 @@ BUILD_DIR="${PROJECT_DIR}/build"
 ARTIFACT_DIR="${PROJECT_DIR}/dist"
 TOOLS_DIR="${PROJECT_DIR}/build-tools"
 PACKAGE_NAME="safe-exam-browser"
-LINUXDEPLOY_VERSION="1-alpha-20250213-2"
+LINUXDEPLOY_VERSION="1-alpha-20251107-1"
 LINUXDEPLOY_PLUGIN_QT_VERSION="1-alpha-20250213-1"
-LINUXDEPLOY_SHA256="4648f278ab3ef31f819e67c30d50f462640e5365a77637d7e6f2ad9fd0b4522a"
+LINUXDEPLOY_SHA256="c20cd71e3a4e3b80c3483cef793cda3f4e990aca14014d23c544ca3ce1270b4d"
 LINUXDEPLOY_PLUGIN_QT_SHA256="15106be885c1c48a021198e7e1e9a48ce9d02a86dd0a1848f00bdbf3c1c92724"
 LINUXDEPLOY_URL="https://github.com/linuxdeploy/linuxdeploy/releases/download/${LINUXDEPLOY_VERSION}/linuxdeploy-x86_64.AppImage"
 LINUXDEPLOY_PLUGIN_QT_URL="https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/${LINUXDEPLOY_PLUGIN_QT_VERSION}/linuxdeploy-plugin-qt-x86_64.AppImage"
@@ -133,11 +133,6 @@ build_appimage() {
 echo "Installing dependencies"
 ${ROOT_DIR}/scripts/dependencies.sh
 
-unset QML_SOURCES_PATHS
-unset QMAKE
-unset EXTRA_QT_MODULES
-export QML_SOURCES_PATHS="$PROJECT_DIR"/src
-export QMAKE=$(which qmake6)
 export EXTRA_QT_MODULES="libssl;libcrypto"
 echo "Environment variables set"
 

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROJECT_DIR="${ROOT_DIR}"
-VERSION="${1:-0.1.0}"
+export VERSION="${1:-0.1.0}"
+export PACKAGE_NAME="safe-exam-browser"
 BUILD_DIR="${PROJECT_DIR}/build"
 ARTIFACT_DIR="${PROJECT_DIR}/dist"
 TOOLS_DIR="${PROJECT_DIR}/build-tools"
-PACKAGE_NAME="safe-exam-browser"
 LINUXDEPLOY_VERSION="1-alpha-20251107-1"
 LINUXDEPLOY_PLUGIN_QT_VERSION="1-alpha-20250213-1"
 LINUXDEPLOY_SHA256="c20cd71e3a4e3b80c3483cef793cda3f4e990aca14014d23c544ca3ce1270b4d"
@@ -30,7 +30,6 @@ LINUXBUILD_EXTRA_ARGS=(
     -l /usr/lib/x86_64-linux-gnu/libxcb-cursor.so.0
     -l /usr/lib/x86_64-linux-gnu/libxcb-xinput.so.0
 )
-export VERSION="${1:-0.1.0}"
 echo "Variables set"
 
 GENERATOR_ARGS=()

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -30,6 +30,7 @@ LINUXBUILD_EXTRA_ARGS=(
     -l /usr/lib/x86_64-linux-gnu/libxcb-cursor.so.0
     -l /usr/lib/x86_64-linux-gnu/libxcb-xinput.so.0
 )
+CMAKE_ARGS=("$@")
 echo "Variables set"
 
 GENERATOR_ARGS=()
@@ -98,7 +99,7 @@ build_appimage() {
     mkdir -p "${build_dir}" "${app_dir}" "${appimage_output_dir}"
 
     pushd "${build_dir}" >/dev/null
-    cmake -S "${PROJECT_DIR}" -B "${build_dir}" ${GENERATOR_ARGS[@]+"${GENERATOR_ARGS[@]}"} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr "${config}"
+    cmake -S "${PROJECT_DIR}" -B "${build_dir}" ${CMAKE_ARGS[@]+"${CMAKE_ARGS[@]}"} ${GENERATOR_ARGS[@]+"${GENERATOR_ARGS[@]}"} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr "${config}"
     run_logged "${build_dir}/make.log" cmake --build "${build_dir}" -j"$(nproc)"
     run_logged "${build_dir}/make-install.log" env DESTDIR="${app_dir}" cmake --install "${build_dir}"
     popd >/dev/null

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "app_controller.h"
 #include "security/security_service.h"
 #include "browser/webengine_environment.h"
@@ -315,6 +316,8 @@ void applyCommandLineOverrides(const QCommandLineParser &parser, seb::SebSetting
 
 }  // namespace
 
+std::string version = VERSION;
+
 int main(int argc, char *argv[])
 {
     applyEarlyEnvironment(argc, argv);
@@ -325,7 +328,7 @@ int main(int argc, char *argv[])
     app.setWindowIcon(appIcon);
     app.setDesktopFileName(QStringLiteral("safe-exam-browser"));
     QCoreApplication::setApplicationName(QStringLiteral("Safe Exam Browser"));
-    QCoreApplication::setApplicationVersion(QStringLiteral("0.1.0"));
+    QCoreApplication::setApplicationVersion(QStringLiteral(version));
 
     QCommandLineParser parser;
     parser.setApplicationDescription(QStringLiteral(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -326,7 +326,6 @@ int main(int argc, char *argv[])
     
      const QIcon appIcon(QStringLiteral(":/assets/icons/safe-exam-browser.png"));
     app.setWindowIcon(appIcon);
-    // TODO: Dynamic package name.
     app.setDesktopFileName(packagename);
     QCoreApplication::setApplicationName(QStringLiteral("Safe Exam Browser"));
     QCoreApplication::setApplicationVersion(version);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -317,6 +317,7 @@ void applyCommandLineOverrides(const QCommandLineParser &parser, seb::SebSetting
 }  // namespace
 
 const QString version = QString::fromStdString(VERSION);
+const QString packagename = QString::fromStdString(PACKAGE_NAME);
 
 int main(int argc, char *argv[])
 {
@@ -327,7 +328,7 @@ int main(int argc, char *argv[])
      const QIcon appIcon(QStringLiteral(":/assets/icons/safe-exam-browser.png"));
     app.setWindowIcon(appIcon);
     // TODO: Dynamic package name.
-    app.setDesktopFileName(QStringLiteral("safe-exam-browser"));
+    app.setDesktopFileName(packagename);
     QCoreApplication::setApplicationName(QStringLiteral("Safe Exam Browser"));
     QCoreApplication::setApplicationVersion(version);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -315,8 +315,8 @@ void applyCommandLineOverrides(const QCommandLineParser &parser, seb::SebSetting
 
 }  // namespace
 
-const QString version = QString::fromStdString(VERSION);
-const QString packagename = QString::fromStdString(PACKAGE_NAME);
+const QString version = QString::fromUtf8(VERSION);
+const QString packagename = QString::fromUtf8(PACKAGE_NAME);
 
 int main(int argc, char *argv[])
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -316,7 +316,7 @@ void applyCommandLineOverrides(const QCommandLineParser &parser, seb::SebSetting
 
 }  // namespace
 
-std::string version = VERSION;
+const Qstring version = QString::fromStdString(VERSION);
 
 int main(int argc, char *argv[])
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include "app_controller.h"
 #include "security/security_service.h"
 #include "browser/webengine_environment.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -326,9 +326,10 @@ int main(int argc, char *argv[])
     
      const QIcon appIcon(QStringLiteral(":/assets/icons/safe-exam-browser.png"));
     app.setWindowIcon(appIcon);
+    // TODO: Dynamic package name.
     app.setDesktopFileName(QStringLiteral("safe-exam-browser"));
     QCoreApplication::setApplicationName(QStringLiteral("Safe Exam Browser"));
-    QCoreApplication::setApplicationVersion(QStringLiteral(version));
+    QCoreApplication::setApplicationVersion(version);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(QStringLiteral(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -316,7 +316,7 @@ void applyCommandLineOverrides(const QCommandLineParser &parser, seb::SebSetting
 
 }  // namespace
 
-const Qstring version = QString::fromStdString(VERSION);
+const QString version = QString::fromStdString(VERSION);
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
## Summary

- Cleaned up some lines for the AppImage building.
- Updated LinuxDeploy. 
- Pointed out unfixable GTK issue in the README as known issue.
- Fix -v always reporting v0.1.0.
- Make application name dynamic and follow the environment variable in the build-release script.

## Verification

- I've ran both builds from my fork and there seem to be no regressions or failures.
-  <img width="851" height="106" alt="image" src="https://github.com/user-attachments/assets/ffbcc9bf-7546-4226-bf59-fb3ac51e8417" />

(the version numbers on my fork are all over the place but it is correct in this image.)